### PR TITLE
Update 5.HowToMint.md

### DIFF
--- a/bitcoin_cli_channel/bitcoin_cli_channel.go
+++ b/bitcoin_cli_channel/bitcoin_cli_channel.go
@@ -20,7 +20,7 @@ func GetBlockCount() int {
 		return 0
 	}
 	outputStr := string(output)
-	outputStr = strings.Trim(outputStr, "\t\n")
+	outputStr = strings.TrimSpace(outputStr)
 	result, ok := strconv.Atoi(outputStr)
 	if ok == nil {
 		return result
@@ -36,7 +36,7 @@ func GetBlockHash(blockNumber int) *string {
 		return nil
 	}
 	outputStr := string(output)
-	outputStr = strings.Trim(outputStr, "\t\n")
+	outputStr = strings.TrimSpace(outputStr)
 	return &outputStr
 }
 
@@ -85,7 +85,7 @@ func GetRawTransaction(txId string) *string {
 		return nil
 	}
 	outputStr := string(output)
-	outputStr = strings.Trim(outputStr, "\t\n")
+	outputStr = strings.TrimSpace(outputStr)
 	return &outputStr
 }
 

--- a/docs/5.HowToMint.md
+++ b/docs/5.HowToMint.md
@@ -1,5 +1,9 @@
 # How to Mint ODFI & ODGV
 
+## Step0 ❕: Windows Is Not Currently Supported
+
+* Will be compatible with Windows soon.
+
 ## Step1 💻: Install Requirements
 
 * Install [Bitcoin Core](https://github.com/bitcoin/bitcoin/releases) v24.0.1 or above;


### PR DESCRIPTION
Added a tip that does not support Windows
outputStr = strings.Trim(outputStr, "\t\n"), in windows it is \r
I'm not sure if there are other codes that are not Windows compatible, so I suggest adding a tip first